### PR TITLE
fsck.overlay: check if the underlying layer is nested overlayfs

### DIFF
--- a/fsck.c
+++ b/fsck.c
@@ -171,10 +171,16 @@ static int ovl_basic_check_layer(struct ovl_layer *layer)
 	if (statfs.f_flags & ST_RDONLY)
 		layer->flag |= FS_LAYER_RO;
 
+	/* A nested overlayfs does not support OVL_XATTR_PREFIX xattr */
+	if (statfs.f_type == OVERLAYFS_SUPER_MAGIC) {
+		layer->flag |= FS_LAYER_XATTR;
+		return 0;
+	}
+
 	/* Check the underlying layer support xattr or not */
 	ret = fgetxattr(layer->fd, OVL_XATTR_PREFIX, NULL, 0);
 	if (ret < 0 && errno != ENOTSUP && errno != ENODATA) {
-		print_err(_("flistxattr failed:%s\n"), strerror(errno));
+		print_err(_("fgetxattr failed:%s\n"), strerror(errno));
 		return -1;
 	} else if (ret >= 0 || errno == ENODATA) {
 		layer->flag |= FS_LAYER_XATTR;

--- a/overlayfs.h
+++ b/overlayfs.h
@@ -25,6 +25,8 @@
 #ifndef OVL_OVERLAYFS_H
 #define OVL_OVERLAYFS_H
 
+#define OVERLAYFS_SUPER_MAGIC 0x794c7630
+
 /* Name of overlay filesystem type */
 #define OVERLAY_NAME "overlay"
 


### PR DESCRIPTION
This lets fsck.overlay pass on my new ovl-nested xfstests